### PR TITLE
Fix some 404 pages

### DIFF
--- a/web/bfex/common/utils.py
+++ b/web/bfex/common/utils.py
@@ -44,6 +44,7 @@ class FacultyNames:
         name_list = FacultyNames.split_regex.sub(r' \1', name).replace(r'.', r'').split()
 
         url_safe = '-'.join(name_list)
+        url_safe = url_safe.replace("--", "-")
 
         return url_safe.lower()
 


### PR DESCRIPTION
This fixes names with a hyphen in them. Many of the other 404 pages are because either the prof isn't there or because their url is in a different form (eg. Jeffrey Stryker has  j-stryker)